### PR TITLE
Fix Windows compatibility and reduce hook verbosity

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -12,8 +12,8 @@
   "skills": "./skills",
   "mcpServers": {
     "callme": {
-      "command": "bash",
-      "args": ["-c", "cd ${CLAUDE_PLUGIN_ROOT}/server && bun install --silent && bun run src/index.ts"],
+      "command": "bun",
+      "args": ["run", "--cwd", "${CLAUDE_PLUGIN_ROOT}/server", "start"],
       "env": {
         "CALLME_PHONE_ACCOUNT_SID": "${CALLME_PHONE_ACCOUNT_SID}",
         "CALLME_PHONE_AUTH_TOKEN": "${CALLME_PHONE_AUTH_TOKEN}",
@@ -34,7 +34,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Evaluate if Claude should call the user to report progress or ask for what to do next. If yes, use the initiate_call tool."
+            "prompt": "SILENTLY evaluate if you should call the user. ONLY use initiate_call if you completed significant work and need to discuss next steps, or are genuinely blocked. Do NOT output any text - either call or do nothing."
           }
         ]
       }

--- a/server/package.json
+++ b/server/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
+    "prestart": "bun install --silent",
     "start": "bun run src/index.ts",
     "dev": "bun --watch src/index.ts"
   },


### PR DESCRIPTION
## Summary

- Use `bun` directly as the command instead of `bash`, eliminating WSL/shell dependency
- Add `--cwd` flag for cross-platform directory handling  
- Add `prestart` script in package.json to auto-install dependencies
- Make Stop hook quieter (no output unless actually calling)

## Problem

On Windows, the plugin fails because:
1. `bash` command defaults to WSL
2. Windows paths (`C:\Users\...`) get mangled when passed through WSL bash - backslashes are interpreted as escape characters
3. Results in errors like: `cd: C:UsersName.claudeplugins...: No such file or directory`

## Solution

Instead of relying on bash shell:
```json
"command": "bun",
"args": ["run", "--cwd", "${CLAUDE_PLUGIN_ROOT}/server", "start"]
```

This works cross-platform (Windows, macOS, Linux) as long as `bun` is in PATH.

## Testing

Tested on Windows 11 with native Windows bun installation. Plugin starts successfully and connects to Telnyx API.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)