### PR TITLE
feat: SMS enhancements - fallback + two-way messaging

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -102,6 +102,25 @@ async function main() {
             required: ['call_id', 'message'],
           },
         },
+        {
+          name: 'check_messages',
+          description: 'Check for SMS messages from the user. Use this to see if the user replied to a previous SMS or voicemail fallback. Returns any pending messages and clears the queue.',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+          },
+        },
+        {
+          name: 'send_sms',
+          description: 'Send an SMS text message to the user. Use this for async communication when a phone call is not needed.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              message: { type: 'string', description: 'The text message to send' },
+            },
+            required: ['message'],
+          },
+        },
       ],
     };
   });
@@ -145,6 +164,34 @@ async function main() {
 
         return {
           content: [{ type: 'text', text: `Call ended. Duration: ${durationSeconds}s` }],
+        };
+      }
+
+      if (request.params.name === 'check_messages') {
+        const messages = callManager.getMessages();
+
+        if (messages.length === 0) {
+          return {
+            content: [{ type: 'text', text: 'No pending messages.' }],
+          };
+        }
+
+        const formatted = messages.map(m => {
+          const time = new Date(m.timestamp).toLocaleTimeString();
+          return `[${time}] ${m.from}: ${m.body}`;
+        }).join('\n');
+
+        return {
+          content: [{ type: 'text', text: `${messages.length} message(s) received:\n\n${formatted}` }],
+        };
+      }
+
+      if (request.params.name === 'send_sms') {
+        const { message } = request.params.arguments as { message: string };
+        await callManager.sendSms(message);
+
+        return {
+          content: [{ type: 'text', text: `SMS sent: "${message}"` }],
         };
       }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -42,6 +42,19 @@ async function main() {
   const callManager = new CallManager(serverConfig);
   callManager.startServer();
 
+  // Auto-configure Twilio SMS webhook to point to ngrok URL
+  if (serverConfig.providers.phone.configureSmsWebhook) {
+    try {
+      await serverConfig.providers.phone.configureSmsWebhook(
+        serverConfig.phoneNumber,
+        `${publicUrl}/sms`
+      );
+    } catch (error) {
+      console.error('Warning: Failed to configure SMS webhook:', error instanceof Error ? error.message : error);
+      console.error('Inbound SMS will not work until manually configured.');
+    }
+  }
+
   // Create stdio MCP server
   const mcpServer = new Server(
     { name: 'callme', version: '3.0.0' },

--- a/server/src/phone-call.ts
+++ b/server/src/phone-call.ts
@@ -27,6 +27,8 @@ interface CallState {
   startTime: number;
   hungUp: boolean;
   sttSession: RealtimeSTTSession | null;
+  pendingMessage: string;  // Message to send as SMS if call not answered
+  answeredByMachine: boolean;  // Track if voicemail/machine answered
 }
 
 export interface ServerConfig {
@@ -37,6 +39,7 @@ export interface ServerConfig {
   providers: ProviderRegistry;
   providerConfig: ProviderConfig;  // For webhook signature verification
   transcriptTimeoutMs: number;
+  smsFallback: boolean;  // Send SMS if call not answered
 }
 
 export function loadServerConfig(publicUrl: string): ServerConfig {
@@ -56,6 +59,9 @@ export function loadServerConfig(publicUrl: string): ServerConfig {
   // Default 3 minutes for transcript timeout
   const transcriptTimeoutMs = parseInt(process.env.CALLME_TRANSCRIPT_TIMEOUT_MS || '180000', 10);
 
+  // SMS fallback enabled by default, set CALLME_SMS_FALLBACK=false to disable
+  const smsFallback = process.env.CALLME_SMS_FALLBACK !== 'false';
+
   return {
     publicUrl,
     port: parseInt(process.env.CALLME_PORT || '3333', 10),
@@ -64,6 +70,7 @@ export function loadServerConfig(publicUrl: string): ServerConfig {
     providers,
     providerConfig,
     transcriptTimeoutMs,
+    smsFallback,
   };
 }
 
@@ -120,7 +127,8 @@ export class CallManager {
           console.error(`[Security] WebSocket token validated for call ${callId}`);
         } else if (!callId) {
           // Token missing or not found - only allow fallback for ngrok free tier
-          const isNgrokFreeTier = new URL(this.config.publicUrl).hostname.endsWith('.ngrok-free.dev');
+          const hostname = new URL(this.config.publicUrl).hostname;
+          const isNgrokFreeTier = hostname.endsWith('.ngrok-free.dev') || hostname.endsWith('.ngrok-free.app');
           if (isNgrokFreeTier) {
             // Fallback: find the most recent active call (ngrok compatibility mode)
             // Token lookup can fail due to timing issues with ngrok's free tier
@@ -281,7 +289,8 @@ export class CallManager {
           const webhookUrl = `${this.config.publicUrl}/twiml`;
 
           if (!validateTwilioSignature(authToken, signature, webhookUrl, params)) {
-            const isNgrokFreeTier = new URL(this.config.publicUrl).hostname.endsWith('.ngrok-free.dev');
+            const hostname = new URL(this.config.publicUrl).hostname;
+          const isNgrokFreeTier = hostname.endsWith('.ngrok-free.dev') || hostname.endsWith('.ngrok-free.app');
             if (isNgrokFreeTier) {
               // Only log if ngrok free tier is used
               // Log for debugging but proceed anyway - ngrok free tier causes signature mismatches
@@ -313,8 +322,21 @@ export class CallManager {
   private async handleTwilioWebhook(params: URLSearchParams, res: ServerResponse): Promise<void> {
     const callSid = params.get('CallSid');
     const callStatus = params.get('CallStatus');
+    const answeredBy = params.get('AnsweredBy');  // AMD result: human, machine_start, machine_end_beep, etc.
 
-    console.error(`Twilio webhook: CallSid=${callSid}, CallStatus=${callStatus}`);
+    console.error(`Twilio webhook: CallSid=${callSid}, CallStatus=${callStatus}, AnsweredBy=${answeredBy}`);
+
+    // Track AMD result when we receive it (comes in early webhooks, not in "completed")
+    if (callSid && answeredBy?.startsWith('machine')) {
+      const callId = this.callControlIdToCallId.get(callSid);
+      if (callId) {
+        const state = this.activeCalls.get(callId);
+        if (state) {
+          state.answeredByMachine = true;
+          console.error(`[${callId}] AMD detected: ${answeredBy}`);
+        }
+      }
+    }
 
     // Handle call status updates
     if (callStatus === 'completed' || callStatus === 'busy' || callStatus === 'no-answer' || callStatus === 'failed') {
@@ -325,6 +347,31 @@ export class CallManager {
           this.callControlIdToCallId.delete(callSid);
           const state = this.activeCalls.get(callId);
           if (state) {
+            // Determine if we should send SMS fallback:
+            // - no-answer, busy, failed: call didn't connect
+            // - completed + machine: voicemail answered (tracked from earlier AMD webhook)
+            const callNotAnsweredByHuman =
+              callStatus === 'no-answer' ||
+              callStatus === 'busy' ||
+              callStatus === 'failed' ||
+              (callStatus === 'completed' && state.answeredByMachine);
+
+            // Send SMS fallback if call was not answered by human and SMS fallback is enabled
+            if (callNotAnsweredByHuman &&
+                this.config.smsFallback &&
+                state.pendingMessage &&
+                this.config.providers.phone.sendSMS) {
+              try {
+                await this.config.providers.phone.sendSMS(
+                  state.userPhoneNumber,
+                  this.config.phoneNumber,
+                  `[Claude] ${state.pendingMessage}`
+                );
+                console.error(`[${callId}] Call ${callStatus} (machine: ${state.answeredByMachine}), sent SMS fallback`);
+              } catch (error) {
+                console.error(`[${callId}] Failed to send SMS fallback:`, error);
+              }
+            }
             state.hungUp = true;
             state.ws?.close();
           }
@@ -445,6 +492,8 @@ export class CallManager {
       startTime: Date.now(),
       hungUp: false,
       sttSession,
+      pendingMessage: message,  // Store for SMS fallback if call not answered
+      answeredByMachine: false,  // Will be set true if AMD detects voicemail
     };
 
     this.activeCalls.set(callId, state);
@@ -510,6 +559,23 @@ export class CallManager {
 
     // Wait for audio to finish playing before hanging up (prevent cutoff)
     await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    // Send SMS fallback if call was answered by machine (voicemail)
+    if (state.answeredByMachine &&
+        this.config.smsFallback &&
+        state.pendingMessage &&
+        this.config.providers.phone.sendSMS) {
+      try {
+        await this.config.providers.phone.sendSMS(
+          state.userPhoneNumber,
+          this.config.phoneNumber,
+          `[Claude] ${state.pendingMessage}`
+        );
+        console.error(`[${callId}] Voicemail detected, sent SMS fallback`);
+      } catch (error) {
+        console.error(`[${callId}] Failed to send SMS fallback:`, error);
+      }
+    }
 
     // Hang up the call via phone provider
     if (state.callControlId) {

--- a/server/src/phone-call.ts
+++ b/server/src/phone-call.ts
@@ -74,6 +74,13 @@ export function loadServerConfig(publicUrl: string): ServerConfig {
   };
 }
 
+interface IncomingSMS {
+  from: string;
+  body: string;
+  timestamp: number;
+  sid: string;
+}
+
 export class CallManager {
   private activeCalls = new Map<string, CallState>();
   private callControlIdToCallId = new Map<string, string>();
@@ -82,6 +89,7 @@ export class CallManager {
   private wss: WebSocketServer | null = null;
   private config: ServerConfig;
   private currentCallId = 0;
+  private incomingSmsQueue: IncomingSMS[] = [];  // Queue for incoming SMS
 
   constructor(config: ServerConfig) {
     this.config = config;
@@ -93,6 +101,11 @@ export class CallManager {
 
       if (url.pathname === '/twiml') {
         this.handlePhoneWebhook(req, res);
+        return;
+      }
+
+      if (url.pathname === '/sms') {
+        this.handleSmsWebhook(req, res);
         return;
       }
 
@@ -467,6 +480,76 @@ export class CallManager {
     } catch (error) {
       console.error(`Error handling webhook ${eventType}:`, error);
     }
+  }
+
+  /**
+   * Handle incoming SMS webhook from Twilio
+   */
+  private handleSmsWebhook(req: IncomingMessage, res: ServerResponse): void {
+    let body = '';
+    req.on('data', (chunk) => { body += chunk; });
+    req.on('end', () => {
+      try {
+        const params = new URLSearchParams(body);
+        const from = params.get('From') || '';
+        const smsBody = params.get('Body') || '';
+        const messageSid = params.get('MessageSid') || '';
+
+        console.error(`[SMS] Received from ${from}: ${smsBody}`);
+
+        // Add to queue
+        this.incomingSmsQueue.push({
+          from,
+          body: smsBody,
+          timestamp: Date.now(),
+          sid: messageSid,
+        });
+
+        // Keep only last 50 messages
+        if (this.incomingSmsQueue.length > 50) {
+          this.incomingSmsQueue.shift();
+        }
+
+        // Respond with empty TwiML (no auto-reply)
+        res.writeHead(200, { 'Content-Type': 'application/xml' });
+        res.end('<?xml version="1.0" encoding="UTF-8"?><Response></Response>');
+      } catch (error) {
+        console.error('[SMS] Error handling webhook:', error);
+        res.writeHead(500);
+        res.end('Error');
+      }
+    });
+  }
+
+  /**
+   * Get pending SMS messages (for MCP tool)
+   */
+  getMessages(): IncomingSMS[] {
+    const messages = [...this.incomingSmsQueue];
+    this.incomingSmsQueue = [];  // Clear after reading
+    return messages;
+  }
+
+  /**
+   * Check if there are pending messages (for MCP tool)
+   */
+  hasMessages(): boolean {
+    return this.incomingSmsQueue.length > 0;
+  }
+
+  /**
+   * Send an SMS message (for MCP tool)
+   */
+  async sendSms(message: string): Promise<void> {
+    if (!this.config.providers.phone.sendSMS) {
+      throw new Error('SMS not supported by current phone provider');
+    }
+    await this.config.providers.phone.sendSMS(
+      this.config.userPhoneNumber,
+      this.config.phoneNumber,
+      message
+    );
+    console.error(`[SMS] Sent to ${this.config.userPhoneNumber}: ${message}`);
   }
 
   async initiateCall(message: string): Promise<{ callId: string; response: string }> {

--- a/server/src/providers/phone-twilio.ts
+++ b/server/src/providers/phone-twilio.ts
@@ -122,4 +122,40 @@ export class TwilioPhoneProvider implements PhoneProvider {
   </Connect>
 </Response>`;
   }
+
+  /**
+   * Send an SMS message using Twilio Messages API
+   * Used as fallback when call is not answered
+   */
+  async sendSMS(to: string, from: string, message: string): Promise<void> {
+    if (!this.accountSid || !this.authToken) {
+      throw new Error('Twilio not initialized');
+    }
+
+    const auth = Buffer.from(`${this.accountSid}:${this.authToken}`).toString('base64');
+
+    const response = await fetch(
+      `https://api.twilio.com/2010-04-01/Accounts/${this.accountSid}/Messages.json`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Basic ${auth}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          To: to,
+          From: from,
+          Body: message,
+        }).toString(),
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      console.error(`Twilio SMS failed: ${response.status} ${error}`);
+      throw new Error(`Twilio SMS failed: ${response.status}`);
+    }
+
+    console.error(`[SMS] Sent to ${to}: ${message.substring(0, 50)}...`);
+  }
 }

--- a/server/src/providers/phone-twilio.ts
+++ b/server/src/providers/phone-twilio.ts
@@ -158,4 +158,59 @@ export class TwilioPhoneProvider implements PhoneProvider {
 
     console.error(`[SMS] Sent to ${to}: ${message.substring(0, 50)}...`);
   }
+
+  /**
+   * Configure the phone number's SMS webhook URL
+   * This auto-updates the Twilio number to point to the ngrok URL
+   */
+  async configureSmsWebhook(phoneNumber: string, webhookUrl: string): Promise<void> {
+    if (!this.accountSid || !this.authToken) {
+      throw new Error('Twilio not initialized');
+    }
+
+    const auth = Buffer.from(`${this.accountSid}:${this.authToken}`).toString('base64');
+
+    // First, look up the phone number SID
+    const lookupResponse = await fetch(
+      `https://api.twilio.com/2010-04-01/Accounts/${this.accountSid}/IncomingPhoneNumbers.json?PhoneNumber=${encodeURIComponent(phoneNumber)}`,
+      {
+        headers: { 'Authorization': `Basic ${auth}` },
+      }
+    );
+
+    if (!lookupResponse.ok) {
+      const error = await lookupResponse.text();
+      throw new Error(`Failed to lookup phone number: ${lookupResponse.status} ${error}`);
+    }
+
+    const lookupData = await lookupResponse.json() as { incoming_phone_numbers: Array<{ sid: string }> };
+    if (!lookupData.incoming_phone_numbers?.length) {
+      throw new Error(`Phone number ${phoneNumber} not found in account`);
+    }
+
+    const phoneSid = lookupData.incoming_phone_numbers[0].sid;
+
+    // Update the SMS webhook URL
+    const updateResponse = await fetch(
+      `https://api.twilio.com/2010-04-01/Accounts/${this.accountSid}/IncomingPhoneNumbers/${phoneSid}.json`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Basic ${auth}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          SmsUrl: webhookUrl,
+          SmsMethod: 'POST',
+        }).toString(),
+      }
+    );
+
+    if (!updateResponse.ok) {
+      const error = await updateResponse.text();
+      throw new Error(`Failed to update SMS webhook: ${updateResponse.status} ${error}`);
+    }
+
+    console.error(`[Twilio] Configured SMS webhook: ${webhookUrl}`);
+  }
 }

--- a/server/src/providers/types.ts
+++ b/server/src/providers/types.ts
@@ -41,6 +41,11 @@ export interface PhoneProvider {
    * Send an SMS message (optional - for fallback when call not answered)
    */
   sendSMS?(to: string, from: string, message: string): Promise<void>;
+
+  /**
+   * Configure the phone number's SMS webhook URL (optional - for auto-config on startup)
+   */
+  configureSmsWebhook?(phoneNumber: string, webhookUrl: string): Promise<void>;
 }
 
 export interface PhoneConfig {

--- a/server/src/providers/types.ts
+++ b/server/src/providers/types.ts
@@ -36,6 +36,11 @@ export interface PhoneProvider {
    * Get XML response for connecting media stream (used in webhooks)
    */
   getStreamConnectXml(streamUrl: string): string;
+
+  /**
+   * Send an SMS message (optional - for fallback when call not answered)
+   */
+  sendSMS?(to: string, from: string, message: string): Promise<void>;
 }
 
 export interface PhoneConfig {


### PR DESCRIPTION
## Summary

This PR adds SMS capabilities to CallMe:

### 1. SMS Fallback on Voicemail (Fixes #21 partially)
When a call goes to voicemail (detected via Twilio AMD), automatically sends the original message as an SMS.

- Configurable via `CALLME_SMS_FALLBACK` env var (default: true)
- Uses Twilio's Machine Detection (`AnsweredBy=machine_*`)
- Prefixes SMS with `[Claude]` for clarity

### 2. Fix ngrok Free Tier Domain Detection (Fixes #21)
ngrok free tier uses both `.ngrok-free.dev` and `.ngrok-free.app` domains. Updated detection to support both.

### 3. Two-Way SMS Support
New MCP tools for text-based async communication:

- **`send_sms`** - Send an SMS to the user
- **`check_messages`** - Check for incoming SMS replies

Adds `/sms` webhook endpoint to receive incoming messages from Twilio.

## New Tools

```typescript
// Send a text message
send_sms({ message: "Task completed! Let me know if you need anything." })

// Check for replies
check_messages()  // Returns: "1 message(s) received:\n[9:05 PM] +1234567890: Thanks!"
```

## Configuration

To enable two-way SMS, configure your Twilio phone number's messaging webhook:
- URL: `<ngrok-url>/sms`
- Method: POST

## Test Plan
- [x] Voicemail detection sends SMS fallback
- [x] ngrok `.ngrok-free.app` domains work
- [x] `send_sms` tool sends messages
- [x] `/sms` webhook receives incoming messages
- [x] `check_messages` returns queued messages