### PR TITLE
Feature/elevenlabs tts

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -27,17 +27,5 @@
         "CALLME_STT_SILENCE_DURATION_MS": "${CALLME_STT_SILENCE_DURATION_MS:-800}"
       }
     }
-  },
-  "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "SILENTLY evaluate if you should call the user. ONLY use initiate_call if you completed significant work and need to discuss next steps, or are genuinely blocked. Do NOT output any text - either call or do nothing."
-          }
-        ]
-      }
-    ]
   }
 }

--- a/.env.example
+++ b/.env.example
@@ -25,8 +25,26 @@ CALLME_USER_PHONE_NUMBER=+1234567890
 # ===================
 # Speech Services
 # ===================
-# OpenAI API key (required for speech-to-text and text-to-speech)
+# OpenAI API key (required for speech-to-text, and TTS if using openai provider)
 CALLME_OPENAI_API_KEY=sk-xxx
+
+# TTS Provider: "openai" (default) or "elevenlabs"
+# CALLME_TTS_PROVIDER=openai
+
+# ElevenLabs API key (required if TTS provider is elevenlabs)
+# Get from: https://elevenlabs.io/app/settings/api-keys
+# CALLME_ELEVENLABS_API_KEY=your_elevenlabs_api_key
+
+# TTS Voice:
+# - OpenAI: alloy, echo, fable, onyx (default), nova, shimmer
+# - ElevenLabs: voice ID from https://elevenlabs.io/app/voice-library
+#   Examples: onwK4e9ZLuTAKqWW03F9 (Daniel), 21m00Tcm4TlvDq8ikWAM (Rachel)
+# CALLME_TTS_VOICE=onyx
+
+# TTS Model (optional):
+# - OpenAI: tts-1 (default), tts-1-hd
+# - ElevenLabs: eleven_multilingual_v2 (default), eleven_turbo_v2_5
+# CALLME_TTS_MODEL=
 
 # ===================
 # ngrok

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+CallMe is a Claude Code plugin (MCP server) that lets Claude call users on the phone. It runs locally and uses ngrok to expose webhooks for phone providers.
+
+**Stack**: TypeScript, Bun runtime, MCP protocol
+
+## Commands
+
+```bash
+cd server
+bun install          # Install dependencies
+bun run start        # Start MCP server (production)
+bun run dev          # Start with file watching (development)
+```
+
+No test or lint setup exists.
+
+## Architecture
+
+```
+Claude Code → stdio → MCP Server (index.ts)
+                           │
+                           ├── CallManager (phone-call.ts)
+                           │   ├── Phone Provider (Telnyx/Twilio)
+                           │   ├── TTS Provider (OpenAI)
+                           │   └── STT Provider (OpenAI Realtime)
+                           │
+                           ├── ngrok tunnel (ngrok.ts)
+                           │
+                           └── HTTP/WebSocket Server (webhooks + media streams)
+```
+
+### Key Components
+
+- **server/src/index.ts**: MCP server entry point, registers 4 tools: `initiate_call`, `continue_call`, `speak_to_user`, `end_call`
+- **server/src/phone-call.ts**: Core call management - handles call lifecycle, audio encoding (24kHz PCM → 8kHz mu-law), jitter buffer, WebSocket media streams
+- **server/src/providers/**: Pluggable provider system
+  - `phone-telnyx.ts` / `phone-twilio.ts`: Phone providers
+  - `tts-openai.ts`: Text-to-speech
+  - `stt-openai-realtime.ts`: Real-time speech-to-text with VAD
+- **server/src/ngrok.ts**: Tunnel management with auto-reconnect
+- **server/src/webhook-security.ts**: Signature verification (Twilio HMAC-SHA1, Telnyx Ed25519)
+
+### Audio Flow
+
+User speaks → Phone Provider WebSocket (mu-law 8kHz) → `extractInboundAudio()` → STT session → OpenAI Realtime API → transcript returned to Claude
+
+Outbound: OpenAI TTS (24kHz PCM) → `resample24kTo8k()` (linear interpolation) → mu-law encode → WebSocket → Phone Provider
+
+## Plugin Configuration
+
+- **.claude-plugin/plugin.json**: Plugin manifest with MCP server config and Stop hook
+- **skills/phone-input/SKILL.md**: Skill definition that teaches Claude when/how to use phone tools
+
+The Stop hook silently evaluates whether to call the user after each task completion - only calls for significant work or when blocked.
+
+## Environment Variables
+
+Required: `CALLME_PHONE_PROVIDER`, `CALLME_PHONE_ACCOUNT_SID`, `CALLME_PHONE_AUTH_TOKEN`, `CALLME_PHONE_NUMBER`, `CALLME_USER_PHONE_NUMBER`, `CALLME_OPENAI_API_KEY`, `CALLME_NGROK_AUTHTOKEN`
+
+See `.env.example` for full list with descriptions.

--- a/server/ecosystem.config.cjs
+++ b/server/ecosystem.config.cjs
@@ -18,6 +18,8 @@ module.exports = {
       autorestart: true,
       max_restarts: 10,
       restart_delay: 5000,
+      node_args: '-r dotenv/config',
+      env_file: '.env',
       env: {
         NODE_ENV: 'production',
         CALLME_PUBLIC_URL: 'https://helena-call.ngrok.app',

--- a/server/ecosystem.config.cjs
+++ b/server/ecosystem.config.cjs
@@ -1,0 +1,27 @@
+module.exports = {
+  apps: [
+    {
+      name: 'ngrok',
+      script: 'ngrok',
+      args: 'http 3333 --domain=helena-call.ngrok.app',
+      autorestart: true,
+      max_restarts: 10,
+      restart_delay: 5000,
+    },
+    {
+      name: 'callme',
+      script: 'src/http-server.ts',
+      interpreter: 'bun',
+      cwd: '/Users/lucas/Documents/GitHub/call-me/server',
+      watch: ['src'],
+      ignore_watch: ['node_modules'],
+      autorestart: true,
+      max_restarts: 10,
+      restart_delay: 5000,
+      env: {
+        NODE_ENV: 'production',
+        CALLME_PUBLIC_URL: 'https://helena-call.ngrok.app',
+      },
+    },
+  ],
+};

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,10 @@
   "scripts": {
     "prestart": "bun install --silent",
     "start": "bun run src/index.ts",
-    "dev": "bun --watch src/index.ts"
+    "server": "bun run src/http-server.ts",
+    "dev": "pm2 startOrRestart ecosystem.config.cjs && pm2 logs callme",
+    "dev:stop": "pm2 stop callme",
+    "dev:restart": "pm2 restart callme && pm2 logs callme"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",

--- a/server/src/http-server.ts
+++ b/server/src/http-server.ts
@@ -1,0 +1,149 @@
+#!/usr/bin/env bun
+
+/**
+ * CallMe HTTP Server (standalone)
+ *
+ * Runs the HTTP server + ngrok independently of the MCP.
+ * This allows PM2 to keep the server running while Claude connects via MCP.
+ */
+
+import { CallManager, loadServerConfig } from './phone-call.js';
+import { startNgrok, stopNgrok } from './ngrok.js';
+import { createServer } from 'http';
+
+// Store call manager globally for API access
+let callManager: CallManager | null = null;
+
+async function main() {
+  const port = parseInt(process.env.CALLME_PORT || '3333', 10);
+  const apiPort = parseInt(process.env.CALLME_API_PORT || '3334', 10);
+
+  // Use CALLME_PUBLIC_URL if set (external ngrok or other tunnel), otherwise start ngrok
+  let publicUrl: string;
+  let usingExternalTunnel = false;
+
+  if (process.env.CALLME_PUBLIC_URL) {
+    publicUrl = process.env.CALLME_PUBLIC_URL.replace(/\/$/, ''); // Remove trailing slash
+    usingExternalTunnel = true;
+    console.error(`Using external tunnel: ${publicUrl}`);
+  } else {
+    console.error('Starting ngrok tunnel...');
+    try {
+      publicUrl = await startNgrok(port);
+      console.error(`ngrok tunnel: ${publicUrl}`);
+    } catch (error) {
+      console.error('Failed to start ngrok:', error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  }
+
+  // Load config and start call manager
+  let serverConfig;
+  try {
+    serverConfig = loadServerConfig(publicUrl);
+  } catch (error) {
+    console.error('Configuration error:', error instanceof Error ? error.message : error);
+    await stopNgrok();
+    process.exit(1);
+  }
+
+  callManager = new CallManager(serverConfig);
+  callManager.startServer();
+
+  // Start API server for MCP communication
+  const apiServer = createServer(async (req, res) => {
+    // CORS headers for local requests
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(200);
+      res.end();
+      return;
+    }
+
+    const url = new URL(req.url!, `http://localhost:${apiPort}`);
+
+    // Health check doesn't need POST or body
+    if (url.pathname === '/api/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok', publicUrl }));
+      return;
+    }
+
+    if (req.method !== 'POST') {
+      res.writeHead(405);
+      res.end('Method not allowed');
+      return;
+    }
+
+    // Parse JSON body
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', async () => {
+      try {
+        const data = JSON.parse(body);
+
+        let result: unknown;
+
+        switch (url.pathname) {
+          case '/api/initiate_call':
+            result = await callManager!.initiateCall(data.message);
+            break;
+          case '/api/continue_call':
+            result = { response: await callManager!.continueCall(data.call_id, data.message) };
+            break;
+          case '/api/speak_to_user':
+            await callManager!.speakOnly(data.call_id, data.message);
+            result = { success: true };
+            break;
+          case '/api/end_call':
+            result = await callManager!.endCall(data.call_id, data.message);
+            break;
+          default:
+            res.writeHead(404);
+            res.end('Not found');
+            return;
+        }
+
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(result));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: message }));
+      }
+    });
+  });
+
+  apiServer.listen(apiPort, () => {
+    console.error(`API server listening on port ${apiPort}`);
+  });
+
+  console.error('');
+  console.error('CallMe HTTP Server ready');
+  console.error(`Phone: ${serverConfig.phoneNumber} -> ${serverConfig.userPhoneNumber}`);
+  console.error(`Webhook: ${publicUrl}/twiml`);
+  console.error(`API: http://localhost:${apiPort}/api/*`);
+  console.error('');
+
+  // Graceful shutdown
+  const shutdown = async () => {
+    console.error('\nShutting down...');
+    callManager?.shutdown();
+    apiServer.close();
+    if (!usingExternalTunnel) {
+      await stopNgrok();
+    }
+    process.exit(0);
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/server/src/ngrok.ts
+++ b/server/src/ngrok.ts
@@ -39,6 +39,8 @@ async function doStartNgrok(port: number): Promise<string> {
     authtoken,
     // Use custom domain if configured (paid ngrok feature)
     domain: process.env.CALLME_NGROK_DOMAIN || undefined,
+    // Enable pooling to allow multiple instances with same domain
+    pooling: true,
   });
 
   const url = listener.url();

--- a/server/src/providers/tts-elevenlabs.ts
+++ b/server/src/providers/tts-elevenlabs.ts
@@ -1,0 +1,106 @@
+/**
+ * ElevenLabs TTS Provider
+ *
+ * High-quality multilingual TTS with natural-sounding voices.
+ * Excellent support for Portuguese and other languages.
+ *
+ * Pricing: ~$0.30/1k characters (higher than OpenAI but better quality)
+ */
+
+import type { TTSProvider, TTSConfig } from './types.js';
+
+export class ElevenLabsTTSProvider implements TTSProvider {
+  readonly name = 'elevenlabs';
+  private apiKey: string | null = null;
+  private voiceId: string = 'onwK4e9ZLuTAKqWW03F9'; // Daniel - multilingual
+  private modelId: string = 'eleven_multilingual_v2';
+
+  initialize(config: TTSConfig): void {
+    if (!config.apiKey) {
+      throw new Error('ElevenLabs API key required for TTS');
+    }
+
+    this.apiKey = config.apiKey;
+    this.voiceId = config.voice || 'onwK4e9ZLuTAKqWW03F9';
+    this.modelId = config.model || 'eleven_multilingual_v2';
+
+    console.error(`TTS provider: ElevenLabs (${this.modelId}, voice: ${this.voiceId})`);
+  }
+
+  async synthesize(text: string): Promise<Buffer> {
+    if (!this.apiKey) throw new Error('ElevenLabs TTS not initialized');
+
+    const response = await fetch(
+      `https://api.elevenlabs.io/v1/text-to-speech/${this.voiceId}?output_format=pcm_24000`,
+      {
+        method: 'POST',
+        headers: {
+          'xi-api-key': this.apiKey,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          text,
+          model_id: this.modelId,
+          voice_settings: {
+            stability: 0.5,
+            similarity_boost: 0.75,
+          },
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`ElevenLabs TTS failed: ${response.status} ${error}`);
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    return Buffer.from(arrayBuffer);
+  }
+
+  async *synthesizeStream(text: string): AsyncGenerator<Buffer> {
+    if (!this.apiKey) throw new Error('ElevenLabs TTS not initialized');
+
+    const response = await fetch(
+      `https://api.elevenlabs.io/v1/text-to-speech/${this.voiceId}/stream?output_format=pcm_24000`,
+      {
+        method: 'POST',
+        headers: {
+          'xi-api-key': this.apiKey,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          text,
+          model_id: this.modelId,
+          voice_settings: {
+            stability: 0.5,
+            similarity_boost: 0.75,
+          },
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`ElevenLabs TTS stream failed: ${response.status} ${error}`);
+    }
+
+    const body = response.body;
+    if (!body) {
+      throw new Error('No response body from ElevenLabs TTS');
+    }
+
+    const reader = body.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) {
+          yield Buffer.from(value);
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a significant architectural refactor to the CallMe plugin, separating the HTTP server from the MCP server and improving provider flexibility. It also adds support for ElevenLabs as a TTS provider, enhances configuration, and updates documentation for easier onboarding and clarity. The main changes are grouped below.

**1. Architectural Refactor: Decoupling HTTP and MCP Servers**
- Introduced a new standalone HTTP server (`server/src/http-server.ts`) to handle phone calls, webhooks, and ngrok tunneling, allowing it to be managed independently (e.g., via PM2), while the MCP server (`server/src/index.ts`) now connects to this HTTP server via a local API instead of managing calls directly. [[1]](diffhunk://#diff-138857ad4cd95fe865de0b04664a73f822cb5dc9a0c5b3ce6623ee5090567671R1-R149) [[2]](diffhunk://#diff-c299744f73df4daa7a22854dda2023b68bfc8a5d59d8fb90b3a53b0c2842d807L6-R51) [[3]](diffhunk://#diff-c299744f73df4daa7a22854dda2023b68bfc8a5d59d8fb90b3a53b0c2842d807L114-R122) [[4]](diffhunk://#diff-c299744f73df4daa7a22854dda2023b68bfc8a5d59d8fb90b3a53b0c2842d807L126-R143) [[5]](diffhunk://#diff-c299744f73df4daa7a22854dda2023b68bfc8a5d59d8fb90b3a53b0c2842d807L144-R155) [[6]](diffhunk://#diff-c299744f73df4daa7a22854dda2023b68bfc8a5d59d8fb90b3a53b0c2842d807L165-R173)

- Added a PM2 configuration (`server/ecosystem.config.cjs`) and updated scripts in `server/package.json` to support process management and streamlined development workflows. [[1]](diffhunk://#diff-811f2bb1896a89ab57e87c11a213c19a8ffb05967883ea641a950421161d1740R1-R29) [[2]](diffhunk://#diff-da00458cdaeaea2314cb0e0101c85130593048072ada62de01727958c5d6ca37L10-R13)

**2. Provider and Configuration Enhancements**
- Added support for ElevenLabs as a TTS provider, including new environment variables and provider selection logic in `server/src/providers/index.ts`. The provider config now supports both OpenAI and ElevenLabs TTS, with flexible voice/model selection. [[1]](diffhunk://#diff-0a20a646f4863879de8a0d09a1072868034a474fe07a4639bdb2ff3ca06c68c5R12-R18) [[2]](diffhunk://#diff-0a20a646f4863879de8a0d09a1072868034a474fe07a4639bdb2ff3ca06c68c5L33-R48) [[3]](diffhunk://#diff-0a20a646f4863879de8a0d09a1072868034a474fe07a4639bdb2ff3ca06c68c5R61-R77) [[4]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL28-R48)

**3. Security and ngrok Compatibility Improvements**
- Improved ngrok compatibility by expanding detection logic and enabling pooling for custom domains. Also, relaxed Twilio signature validation for all ngrok tunnels to address header issues, with clear logging and a TODO to re-enable strict validation in the future. [[1]](diffhunk://#diff-fabb4aeb5d5eeb7016f5137ef5fb9a4d2bf319644b20c05e7ee978c88f1334ffR42-R43) [[2]](diffhunk://#diff-028bbd58971227aa47fcdd384224b6d5543d90abc16fa1d94afbe08da5d8a068L122-R125) [[3]](diffhunk://#diff-028bbd58971227aa47fcdd384224b6d5543d90abc16fa1d94afbe08da5d8a068L283-R293)

**4. Documentation and Onboarding**
- Added a comprehensive `CLAUDE.md` guide for Claude Code, covering architecture, commands, environment variables, and plugin configuration to facilitate onboarding and code understanding.
- Expanded `.env.example` with detailed documentation for TTS provider options and configuration.

**5. Plugin Manifest and Housekeeping**
- Removed the unused Stop hook from `.claude-plugin/plugin.json`, as the call initiation logic is now handled elsewhere.

These changes collectively modernize the CallMe plugin's architecture, improve provider flexibility, and make the system more robust and maintainable.