### PR TITLE
feat: support CALLME_PUBLIC_URL for self-hosted deployments

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -50,20 +50,33 @@ async function main() {
     process.exit(1);
   }
 
-  // Start ngrok tunnel pointing at the actual bound port
-  console.error('Starting ngrok tunnel...');
+  // Publicly-reachable URL where phone providers will POST webhooks.
+  // Two modes:
+  //   1. CALLME_PUBLIC_URL=https://<host> is set — skip ngrok entirely and use
+  //      the provided URL. For self-hosted deployments (VPS, EC2, Tailscale
+  //      Funnel, Cloudflare Tunnel, etc.) where inbound HTTPS is already solved.
+  //   2. Otherwise — start ngrok to expose the ephemeral HTTP port.
   let publicUrl: string;
-  try {
-    publicUrl = await startNgrok(actualPort, (newUrl) => {
-      console.error(`[ngrok] Updating public URL to: ${newUrl}`);
-      callManager.setPublicUrl(newUrl);
-    });
+  const customPublicUrl = process.env.CALLME_PUBLIC_URL?.trim();
+  if (customPublicUrl) {
+    publicUrl = customPublicUrl.replace(/\/+$/, ''); // strip trailing slash
     callManager.setPublicUrl(publicUrl);
-    console.error(`ngrok tunnel: ${publicUrl}`);
-  } catch (error) {
-    console.error('Failed to start ngrok:', error instanceof Error ? error.message : error);
-    await callManager.shutdown();
-    process.exit(1);
+    console.error(`Using CALLME_PUBLIC_URL: ${publicUrl}`);
+    console.error(`(note: inbound traffic must reach port ${actualPort} on this host)`);
+  } else {
+    console.error('Starting ngrok tunnel...');
+    try {
+      publicUrl = await startNgrok(actualPort, (newUrl) => {
+        console.error(`[ngrok] Updating public URL to: ${newUrl}`);
+        callManager.setPublicUrl(newUrl);
+      });
+      callManager.setPublicUrl(publicUrl);
+      console.error(`ngrok tunnel: ${publicUrl}`);
+    } catch (error) {
+      console.error('Failed to start ngrok:', error instanceof Error ? error.message : error);
+      await callManager.shutdown();
+      process.exit(1);
+    }
   }
 
   // Create stdio MCP server


### PR DESCRIPTION
## Motivation

The MCP server currently requires ngrok (via `CALLME_NGROK_AUTHTOKEN`) to expose its webhook endpoint. This makes sense for the common case of a developer running Claude Code on a laptop behind NAT, but it's redundant — and adds a third-party dependency — for deployments on hosts that already have a publicly-reachable HTTPS endpoint.

Examples where ngrok is pure overhead:
- Running CallMe on a VPS / EC2 / DigitalOcean droplet with a valid cert
- Running behind Tailscale Funnel (`<machine>.<tailnet>.ts.net` with auto-issued certs)
- Running behind Cloudflare Tunnel
- Any existing reverse proxy / load balancer with TLS

## Change

If `CALLME_PUBLIC_URL=https://<host>` is set, the server skips ngrok entirely and uses the provided URL as its public URL for Twilio/Telnyx webhook construction (including the `wss://` media-stream URL). Trailing slashes are stripped.

Otherwise the existing ngrok path is unchanged — fully backwards compatible.

`CALLME_NGROK_AUTHTOKEN` remains required when ngrok is actually used, and is correctly not required when `CALLME_PUBLIC_URL` is set (the check happens inside `startNgrok`, which is no longer called in that branch).

## Testing

- Setting `CALLME_PUBLIC_URL=https://foo.example.com` and unsetting `CALLME_NGROK_AUTHTOKEN`: server starts, logs `Using CALLME_PUBLIC_URL: ...`, stays running.
- Unsetting `CALLME_PUBLIC_URL`: existing ngrok behavior intact.
- Shutdown path is unchanged — `stopNgrok()` is already a no-op when no listener exists.

Happy to add a README snippet for the self-hosted deployment case if you'd like.