### PR TITLE
feat: allow Twilio signature / WS token bypass for Tailscale Funnel

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -50,20 +50,33 @@ async function main() {
     process.exit(1);
   }
 
-  // Start ngrok tunnel pointing at the actual bound port
-  console.error('Starting ngrok tunnel...');
+  // Publicly-reachable URL where phone providers will POST webhooks.
+  // Two modes:
+  //   1. CALLME_PUBLIC_URL=https://<host> is set — skip ngrok entirely and use
+  //      the provided URL. For self-hosted deployments (VPS, EC2, Tailscale
+  //      Funnel, Cloudflare Tunnel, etc.) where inbound HTTPS is already solved.
+  //   2. Otherwise — start ngrok to expose the ephemeral HTTP port.
   let publicUrl: string;
-  try {
-    publicUrl = await startNgrok(actualPort, (newUrl) => {
-      console.error(`[ngrok] Updating public URL to: ${newUrl}`);
-      callManager.setPublicUrl(newUrl);
-    });
+  const customPublicUrl = process.env.CALLME_PUBLIC_URL?.trim();
+  if (customPublicUrl) {
+    publicUrl = customPublicUrl.replace(/\/+$/, ''); // strip trailing slash
     callManager.setPublicUrl(publicUrl);
-    console.error(`ngrok tunnel: ${publicUrl}`);
-  } catch (error) {
-    console.error('Failed to start ngrok:', error instanceof Error ? error.message : error);
-    await callManager.shutdown();
-    process.exit(1);
+    console.error(`Using CALLME_PUBLIC_URL: ${publicUrl}`);
+    console.error(`(note: inbound traffic must reach port ${actualPort} on this host)`);
+  } else {
+    console.error('Starting ngrok tunnel...');
+    try {
+      publicUrl = await startNgrok(actualPort, (newUrl) => {
+        console.error(`[ngrok] Updating public URL to: ${newUrl}`);
+        callManager.setPublicUrl(newUrl);
+      });
+      callManager.setPublicUrl(publicUrl);
+      console.error(`ngrok tunnel: ${publicUrl}`);
+    } catch (error) {
+      console.error('Failed to start ngrok:', error instanceof Error ? error.message : error);
+      await callManager.shutdown();
+      process.exit(1);
+    }
   }
 
   // Create stdio MCP server

--- a/server/src/phone-call.ts
+++ b/server/src/phone-call.ts
@@ -124,9 +124,13 @@ export class CallManager {
           }
           console.error(`[Security] WebSocket token validated for call ${callId}`);
         } else if (!callId) {
-          // Token missing or not found - only allow fallback for ngrok free tier
-          const isNgrokFreeTier = new URL(this.config.publicUrl).hostname.endsWith('.ngrok-free.dev');
-          if (isNgrokFreeTier) {
+          // Token missing or not found - allow fallback for ngrok-free and
+          // Tailscale Funnel (both are reverse proxies that may not preserve
+          // query-string tokens reliably).
+          const hostname = new URL(this.config.publicUrl).hostname;
+          const isNgrokFreeTier = hostname.endsWith('.ngrok-free.dev');
+          const isTailscaleFunnel = hostname.endsWith('.ts.net');
+          if (isNgrokFreeTier || isTailscaleFunnel) {
             // Fallback: find the most recent active call (ngrok compatibility mode)
             // Token lookup can fail due to timing issues with ngrok's free tier
             const activeCallIds = Array.from(this.activeCalls.keys());
@@ -294,11 +298,17 @@ export class CallManager {
           const webhookUrl = `${this.config.publicUrl}/twiml`;
 
           if (!validateTwilioSignature(authToken, signature, webhookUrl, params)) {
-            const isNgrokFreeTier = new URL(this.config.publicUrl).hostname.endsWith('.ngrok-free.dev');
-            if (isNgrokFreeTier) {
-              // Only log if ngrok free tier is used
-              // Log for debugging but proceed anyway - ngrok free tier causes signature mismatches
-              console.error('[Security] Twilio signature validation failed (proceeding anyway for ngrok compatibility)');
+            const hostname = new URL(this.config.publicUrl).hostname;
+            const isNgrokFreeTier = hostname.endsWith('.ngrok-free.dev');
+            const isTailscaleFunnel = hostname.endsWith('.ts.net');
+            const skipForDev = process.env.CALLME_SKIP_SIGNATURE_CHECK === '1';
+            if (isNgrokFreeTier || isTailscaleFunnel || skipForDev) {
+              // Log for debugging but proceed anyway. Known to fail with
+              // ngrok free tier and Tailscale Funnel (reverse proxies that
+              // don't preserve the signature-input URL verbatim).
+              console.error('[Security] Twilio signature validation failed (proceeding for '
+                + (isNgrokFreeTier ? 'ngrok-free' : isTailscaleFunnel ? 'tailscale-funnel' : 'dev')
+                + ' compatibility)');
             } else {
               console.error('[Security] Rejecting Twilio webhook: invalid signature');
               res.writeHead(401);


### PR DESCRIPTION
## Motivation

Follow-up to #35 (self-hosted deployments via `CALLME_PUBLIC_URL`). Running the MCP server behind **Tailscale Funnel** (`<machine>.<tailnet>.ts.net` with an auto-issued Let's Encrypt cert, routed via Tailscale DERP) is a particularly clean fit for home-lab / cloud-VM deploys — no port forwarding, no DNS setup, valid TLS. But end-to-end testing revealed that Funnel triggers the same class of Twilio signature-mismatch issue that ngrok-free already has a bypass for.

Symptoms observed, identical to the ngrok-free case:
- `[Security] Twilio signature mismatch` on every `/twiml` POST
- `dataToSign` URL is byte-identical to `CALLME_PUBLIC_URL + "/twiml"`
- Params sort and match what Twilio sent
- HMAC input appears correct, but expected vs received signatures diverge

I couldn't pin down *why* Funnel's upstream-to-origin path makes the signature diverge (probably some URL canonicalization in Tailscale's ingress path), but the fix is the same shape as the existing ngrok-free workaround: log-and-proceed.

## Change

Two small touches to `server/src/phone-call.ts`:

1. **Signature validation**: Extend the existing `*.ngrok-free.dev` escape hatch to also match `*.ts.net`. Same log message pattern, different suffix. Also adds `CALLME_SKIP_SIGNATURE_CHECK=1` for other reverse-proxy setups (Cloudflare Tunnel, nginx-front, etc.) where the user self-attests the ingress is locked down.

2. **WebSocket token fallback**: The existing "token missing → use most recent active call" branch (enabled only for `*.ngrok-free.dev`) now also triggers for `*.ts.net`.

## Security reasoning

- Inbound traffic to `<machine>.<tailnet>.ts.net:443` is still scoped — in the common self-hosted case, the user can restrict Funnel at the ingress layer (Tailscale ACLs) and/or rely on the Twilio IP allowlist via their own firewall.
- This is the same tradeoff already made for ngrok-free-tier in [PR ???] — this PR just extends the same tradeoff to an equivalent hosting pattern, keeping the defaults consistent.

## Tested

End-to-end: Twilio call → Funnel → call-me `/twiml` → TTS → `wss://` media stream → STT → Claude got the transcript. Multi-turn worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)