### PR TITLE
feat: add Telnyx STT and TTS providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,8 @@ CALLME_OPENAI_API_KEY=sk-xxx
 # for a separate OpenAI account for speech services.
 #
 # STT: streaming transcription via wss://api.telnyx.com/v2/speech-to-text/transcription
-# TTS: synthesis via POST https://api.telnyx.com/v2/text-to-speech/speech
+# TTS: streaming synthesis via wss://api.telnyx.com/v2/text-to-speech/speech
+#       (audio format: linear16 PCM at 24kHz mono; phone bridge resamples to 8kHz mu-law)
 #
 # Set CALLME_STT_PROVIDER=telnyx and/or CALLME_TTS_PROVIDER=telnyx to enable.
 # If CALLME_PHONE_PROVIDER=telnyx, STT defaults to telnyx automatically.

--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,38 @@ CALLME_USER_PHONE_NUMBER=+1234567890
 CALLME_OPENAI_API_KEY=sk-xxx
 
 # ===================
+# Telnyx STT/TTS (optional)
+# ===================
+# When CALLME_PHONE_PROVIDER=telnyx, you can use Telnyx for speech-to-text
+# and text-to-speech too, reusing the same API key. This avoids the need
+# for a separate OpenAI account for speech services.
+#
+# STT: streaming transcription via wss://api.telnyx.com/v2/speech-to-text/transcription
+# TTS: synthesis via POST https://api.telnyx.com/v2/text-to-speech/speech
+#
+# Set CALLME_STT_PROVIDER=telnyx and/or CALLME_TTS_PROVIDER=telnyx to enable.
+# If CALLME_PHONE_PROVIDER=telnyx, STT defaults to telnyx automatically.
+
+# CALLME_STT_PROVIDER=telnyx
+# CALLME_TTS_PROVIDER=telnyx
+
+# Telnyx API key for STT/TTS. Defaults to CALLME_PHONE_AUTH_TOKEN when omitted.
+# CALLME_TELNYX_API_KEY=your_telnyx_api_key
+
+# STT: transcription engine (Telnyx, Deepgram, Google, Azure). Default: Telnyx
+# CALLME_TELNYX_STT_ENGINE=Telnyx
+
+# STT: audio input format (mulaw, linear16, alaw). Default: mulaw (matches phone bridge)
+# CALLME_TELNYX_STT_INPUT_FORMAT=mulaw
+
+# STT: language code (BCP-47, e.g. en-US). Default: en-US
+# CALLME_TELNYX_STT_LANGUAGE=en-US
+
+# TTS: voice ID. See https://api.telnyx.com/v2/text-to-speech/voices for the full catalog.
+# Default: AWS.Polly.Matthew-Neural (en-US male)
+# CALLME_TELNYX_TTS_VOICE=AWS.Polly.Matthew-Neural
+
+# ===================
 # ngrok
 # ===================
 # Get a free auth token at https://dashboard.ngrok.com/get-started/your-authtoken

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ CALLME_PHONE_AUTH_TOKEN=<Auth Token>
 
 ### 3. Set Environment Variables
 
+
 Add these to `~/.claude/settings.json` (recommended) or export them in your shell:
 
 ```json
@@ -91,14 +92,15 @@ Add these to `~/.claude/settings.json` (recommended) or export them in your shel
 | `CALLME_PHONE_AUTH_TOKEN` | Telnyx API Key or Twilio Auth Token |
 | `CALLME_PHONE_NUMBER` | Phone number Claude calls from (E.164 format) |
 | `CALLME_USER_PHONE_NUMBER` | Your phone number to receive calls |
-| `CALLME_OPENAI_API_KEY` | OpenAI API key (required for STT; also for TTS unless using Kokoro) |
+| `CALLME_OPENAI_API_KEY` | OpenAI API key (required for OpenAI STT/TTS; not required when using Telnyx for both STT and TTS) |
 | `CALLME_NGROK_AUTHTOKEN` | ngrok auth token for webhook tunneling |
 
 #### Optional Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `CALLME_TTS_PROVIDER` | `openai` | TTS engine: `openai` or `kokoro` (free, local — see [Kokoro TTS](#kokoro-tts-free-local)) |
+| `CALLME_TTS_PROVIDER` | `openai` | TTS engine: `openai`, `kokoro` (free, local — see [Kokoro TTS](#kokoro-tts-free-local)), or `telnyx` (reuses Telnyx API key) |
+| `CALLME_STT_PROVIDER` | `telnyx`* | STT engine: `openai-realtime` or `telnyx` (reuses Telnyx API key). *Defaults to `telnyx` when `CALLME_PHONE_PROVIDER=telnyx` |
 | `CALLME_TTS_VOICE` | `onyx` / `af_bella` | Voice name (default depends on TTS provider) |
 | `CALLME_KOKORO_URL` | - | URL of existing Kokoro instance (e.g. `http://localhost:8880/v1`). If unset, auto-starts Docker container |
 | `CALLME_PORT` | `0` (auto) | Local HTTP server port (0 = OS picks a free port) |
@@ -106,6 +108,11 @@ Add these to `~/.claude/settings.json` (recommended) or export them in your shel
 | `CALLME_TRANSCRIPT_TIMEOUT_MS` | `180000` | Timeout for user speech (3 minutes) |
 | `CALLME_STT_SILENCE_DURATION_MS` | `800` | Silence duration to detect end of speech |
 | `CALLME_TELNYX_PUBLIC_KEY` | - | Telnyx public key for webhook signature verification (recommended) |
+| `CALLME_TELNYX_STT_ENGINE` | `Telnyx` | Telnyx STT engine: `Telnyx`, `Deepgram`, `Google`, or `Azure` |
+| `CALLME_TELNYX_STT_INPUT_FORMAT` | `mulaw` | Telnyx STT audio format: `mulaw`, `linear16`, or `alaw` |
+| `CALLME_TELNYX_STT_LANGUAGE` | `en-US` | Telnyx STT language (BCP-47 code) |
+| `CALLME_TELNYX_TTS_VOICE` | `AWS.Polly.Matthew-Neural` | Telnyx TTS voice ID (see `/v2/text-to-speech/voices` for catalog) |
+| `CALLME_TELNYX_API_KEY` | - | Telnyx API key for STT/TTS (defaults to `CALLME_PHONE_AUTH_TOKEN`) |
 
 ### 4. Install Plugin
 

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -5,21 +5,27 @@
  * Supports Telnyx or Twilio for phone, OpenAI for TTS and Realtime STT.
  */
 
-import type { PhoneProvider, TTSProvider, RealtimeSTTProvider, ProviderRegistry } from './types.js';
+import type { PhoneProvider, TTSProvider, RealtimeSTTProvider, ProviderRegistry, STTConfig } from './types.js';
 import { TelnyxPhoneProvider } from './phone-telnyx.js';
 import { TwilioPhoneProvider } from './phone-twilio.js';
 import { OpenAITTSProvider } from './tts-openai.js';
 import { KokoroTTSProvider } from './tts-kokoro.js';
 import { OpenAIRealtimeSTTProvider } from './stt-openai-realtime.js';
+import { TelnyxSTTProvider } from './stt-telnyx.js';
+import { TelnyxTTSProvider } from './tts-telnyx.js';
 
 export * from './types.js';
 
 export type PhoneProviderType = 'telnyx' | 'twilio';
-export type TTSProviderType = 'openai' | 'kokoro';
+export type STTProviderType = 'openai-realtime' | 'telnyx';
+export type TTSProviderType = 'openai' | 'kokoro' | 'telnyx';
 
 export interface ProviderConfig {
   // Phone provider selection
   phoneProvider: PhoneProviderType;
+
+  // STT provider selection
+  sttProvider: STTProviderType;
 
   // TTS provider selection
   ttsProvider: TTSProviderType;
@@ -43,6 +49,13 @@ export interface ProviderConfig {
 
   // Kokoro TTS (when ttsProvider is 'kokoro')
   kokoroUrl?: string;
+
+  // Telnyx STT/TTS (uses the same API key as the Telnyx phone provider)
+  telnyxApiKey?: string;
+  telnyxSttEngine?: string;   // 'Telnyx' | 'Deepgram' | 'Google' | 'Azure'
+  telnyxSttInputFormat?: string; // 'mulaw' | 'linear16' | 'alaw'
+  telnyxSttLanguage?: string;
+  telnyxTtsVoice?: string;
 }
 
 export function loadProviderConfig(): ProviderConfig {
@@ -52,10 +65,12 @@ export function loadProviderConfig(): ProviderConfig {
 
   // Default to telnyx if not specified
   const phoneProvider = (process.env.CALLME_PHONE_PROVIDER || 'telnyx') as PhoneProviderType;
+  const sttProvider = (process.env.CALLME_STT_PROVIDER || (process.env.CALLME_PHONE_PROVIDER === 'telnyx' ? 'telnyx' : 'openai-realtime')) as STTProviderType;
   const ttsProvider = (process.env.CALLME_TTS_PROVIDER || 'openai') as TTSProviderType;
 
   return {
     phoneProvider,
+    sttProvider,
     ttsProvider,
     phoneAccountSid: process.env.CALLME_PHONE_ACCOUNT_SID || '',
     phoneAuthToken: process.env.CALLME_PHONE_AUTH_TOKEN || '',
@@ -66,6 +81,11 @@ export function loadProviderConfig(): ProviderConfig {
     sttModel: process.env.CALLME_STT_MODEL || 'gpt-4o-transcribe',
     sttSilenceDurationMs,
     kokoroUrl: process.env.CALLME_KOKORO_URL,
+    telnyxApiKey: process.env.CALLME_TELNYX_API_KEY || process.env.CALLME_PHONE_AUTH_TOKEN,
+    telnyxSttEngine: process.env.CALLME_TELNYX_STT_ENGINE,
+    telnyxSttInputFormat: process.env.CALLME_TELNYX_STT_INPUT_FORMAT,
+    telnyxSttLanguage: process.env.CALLME_TELNYX_STT_LANGUAGE,
+    telnyxTtsVoice: process.env.CALLME_TELNYX_TTS_VOICE,
   };
 }
 
@@ -88,6 +108,15 @@ export function createPhoneProvider(config: ProviderConfig): PhoneProvider {
 }
 
 export function createTTSProvider(config: ProviderConfig): TTSProvider {
+  if (config.ttsProvider === 'telnyx') {
+    const provider = new TelnyxTTSProvider();
+    provider.initialize({
+      apiKey: config.telnyxApiKey || config.phoneAuthToken,
+      voice: config.telnyxTtsVoice,
+    });
+    return provider;
+  }
+
   if (config.ttsProvider === 'kokoro') {
     const provider = new KokoroTTSProvider();
     provider.initialize({
@@ -106,6 +135,18 @@ export function createTTSProvider(config: ProviderConfig): TTSProvider {
 }
 
 export function createSTTProvider(config: ProviderConfig): RealtimeSTTProvider {
+  if (config.sttProvider === 'telnyx') {
+    const provider = new TelnyxSTTProvider();
+    provider.initialize({
+      apiKey: config.telnyxApiKey || config.phoneAuthToken,
+      model: config.telnyxSttLanguage,
+      silenceDurationMs: config.sttSilenceDurationMs,
+      transcriptionEngine: config.telnyxSttEngine,
+      inputFormat: config.telnyxSttInputFormat,
+    } as STTConfig);
+    return provider;
+  }
+
   const provider = new OpenAIRealtimeSTTProvider();
   provider.initialize({
     apiKey: config.openaiApiKey,
@@ -143,8 +184,8 @@ export function validateProviderConfig(config: ProviderConfig): string[] {
   if (!config.phoneNumber) {
     errors.push('Missing CALLME_PHONE_NUMBER');
   }
-  if (!config.openaiApiKey) {
-    errors.push('Missing CALLME_OPENAI_API_KEY (required for speech-to-text, even when using Kokoro TTS)');
+  if (!config.openaiApiKey && config.sttProvider !== 'telnyx' && config.ttsProvider !== 'telnyx') {
+    errors.push('Missing CALLME_OPENAI_API_KEY (required for OpenAI STT/TTS; not required when using Telnyx STT and TTS)');
   }
 
   return errors;

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -184,8 +184,13 @@ export function validateProviderConfig(config: ProviderConfig): string[] {
   if (!config.phoneNumber) {
     errors.push('Missing CALLME_PHONE_NUMBER');
   }
-  if (!config.openaiApiKey && config.sttProvider !== 'telnyx' && config.ttsProvider !== 'telnyx') {
-    errors.push('Missing CALLME_OPENAI_API_KEY (required for OpenAI STT/TTS; not required when using Telnyx STT and TTS)');
+  // OpenAI key is required whenever any non-Telnyx STT or TTS provider is
+  // selected. The previous logic only errored when BOTH were non-Telnyx,
+  // which let mixed configs (e.g. openai-realtime STT + telnyx TTS) start
+  // up clean and then fail at runtime.
+  const needsOpenAI = config.sttProvider === 'openai-realtime' || config.ttsProvider === 'openai';
+  if (!config.openaiApiKey && needsOpenAI) {
+    errors.push('Missing CALLME_OPENAI_API_KEY (required when using OpenAI for STT or TTS)');
   }
 
   return errors;

--- a/server/src/providers/stt-telnyx.ts
+++ b/server/src/providers/stt-telnyx.ts
@@ -1,0 +1,239 @@
+/**
+ * Telnyx STT Provider
+ *
+ * Streaming speech-to-text via the Telnyx WebSocket API.
+ * Endpoint: wss://api.telnyx.com/v2/speech-to-text/transcription
+ *
+ * Uses the same Telnyx API key as the phone provider, so no extra
+ * account or credential is needed when CALLME_PHONE_PROVIDER=telnyx.
+ *
+ * Accepts mu-law audio directly (8kHz mono), which is the format the
+ * phone bridge already produces, so no audio conversion is required.
+ *
+ * Protocol:
+ *   - Connect with Authorization: Bearer <key> header.
+ *   - Config via URL query params: transcription_engine, input_format,
+ *     sample_rate, language, interim_results.
+ *   - Send raw audio as binary WebSocket frames.
+ *   - Receive JSON text frames: { transcript, confidence, is_final }.
+ *   - Send { "type": "CloseStream" } to end the session.
+ */
+
+import WebSocket from 'ws';
+import type { RealtimeSTTProvider, RealtimeSTTSession, STTConfig } from './types.js';
+
+export class TelnyxSTTProvider implements RealtimeSTTProvider {
+  readonly name = 'telnyx';
+  private apiKey: string | null = null;
+  private transcriptionEngine: string = 'Telnyx';
+  private inputFormat: string = 'mulaw';
+  private sampleRate: number = 8000;
+  private language: string = 'en-US';
+  private interimResults: boolean = true;
+  private silenceDurationMs: number = 800;
+
+  initialize(config: STTConfig): void {
+    if (!config.apiKey) {
+      throw new Error('Telnyx API key required for STT');
+    }
+    this.apiKey = config.apiKey;
+    // Telnyx STT accepts mulaw, linear16, alaw. Default to mulaw so the
+    // phone bridge audio can be sent directly without conversion.
+    this.transcriptionEngine = (config as any).transcriptionEngine || 'Telnyx';
+    this.inputFormat = (config as any).inputFormat || 'mulaw';
+    this.sampleRate = (config as any).sampleRate || 8000;
+    this.language = config.model || 'en-US';
+    this.interimResults = (config as any).interimResults !== false;
+    this.silenceDurationMs = config.silenceDurationMs || 800;
+    console.error(
+      `STT provider: Telnyx (${this.transcriptionEngine}, ${this.inputFormat}, ${this.sampleRate}Hz, silence: ${this.silenceDurationMs}ms)`
+    );
+  }
+
+  createSession(): RealtimeSTTSession {
+    if (!this.apiKey) throw new Error('Telnyx STT not initialized');
+    return new TelnyxSTTSession(
+      this.apiKey,
+      this.transcriptionEngine,
+      this.inputFormat,
+      this.sampleRate,
+      this.language,
+      this.interimResults,
+      this.silenceDurationMs
+    );
+  }
+}
+
+class TelnyxSTTSession implements RealtimeSTTSession {
+  private ws: WebSocket | null = null;
+  private apiKey: string;
+  private transcriptionEngine: string;
+  private inputFormat: string;
+  private sampleRate: number;
+  private language: string;
+  private interimResults: boolean;
+  private silenceDurationMs: number;
+  private connected = false;
+  private closed = false;
+  private reconnectAttempts = 0;
+  private maxReconnectAttempts = 5;
+  private reconnectDelayMs = 1000;
+
+  private partialCallback: ((partial: string) => void) | null = null;
+  private transcriptResolve: ((transcript: string) => void) | null = null;
+  private transcriptReject: ((err: Error) => void) | null = null;
+  private transcriptTimeout: NodeJS.Timeout | null = null;
+  private pendingTranscript = '';
+
+  constructor(
+    apiKey: string,
+    transcriptionEngine: string,
+    inputFormat: string,
+    sampleRate: number,
+    language: string,
+    interimResults: boolean,
+    silenceDurationMs: number
+  ) {
+    this.apiKey = apiKey;
+    this.transcriptionEngine = transcriptionEngine;
+    this.inputFormat = inputFormat;
+    this.sampleRate = sampleRate;
+    this.language = language;
+    this.interimResults = interimResults;
+    this.silenceDurationMs = silenceDurationMs;
+  }
+
+  private buildUrl(): string {
+    const params = new URLSearchParams({
+      transcription_engine: this.transcriptionEngine,
+      input_format: this.inputFormat,
+      sample_rate: String(this.sampleRate),
+      language: this.language,
+    });
+    if (this.interimResults) params.set('interim_results', 'true');
+    return `wss://api.telnyx.com/v2/speech-to-text/transcription?${params.toString()}`;
+  }
+
+  async connect(): Promise<void> {
+    this.closed = false;
+    this.reconnectAttempts = 0;
+    return this.doConnect();
+  }
+
+  private async doConnect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(this.buildUrl(), {
+        headers: { Authorization: `Bearer ${this.apiKey}` },
+      });
+
+      ws.on('open', () => {
+        this.connected = true;
+        this.reconnectAttempts = 0;
+        console.error('[Telnyx STT] Connected');
+        resolve();
+      });
+
+      ws.on('message', (data: WebSocket.RawData, isBinary: boolean) => {
+        if (isBinary) return;
+        let msg: any;
+        try {
+          msg = JSON.parse(data.toString());
+        } catch {
+          return;
+        }
+        const text = (msg.transcript || '').trim();
+        if (!text) return;
+
+        const isFinal = msg.is_final === true;
+        if (isFinal) {
+          this.pendingTranscript = this.pendingTranscript
+            ? this.pendingTranscript + ' ' + text
+            : text;
+          if (this.transcriptResolve) {
+            const full = this.pendingTranscript;
+            this.pendingTranscript = '';
+            if (this.transcriptTimeout) clearTimeout(this.transcriptTimeout);
+            this.transcriptTimeout = null;
+            const resolveFn = this.transcriptResolve;
+            this.transcriptResolve = null;
+            this.transcriptReject = null;
+            resolveFn(full);
+          }
+        } else if (this.partialCallback) {
+          this.partialCallback(text);
+        }
+      });
+
+      ws.on('error', (err: Error) => {
+        console.error(`[Telnyx STT] Error: ${err.message}`);
+        if (!this.connected) reject(err);
+        else if (this.transcriptReject) {
+          const rejectFn = this.transcriptReject;
+          this.transcriptReject = null;
+          this.transcriptResolve = null;
+          if (this.transcriptTimeout) clearTimeout(this.transcriptTimeout);
+          rejectFn(err);
+        }
+      });
+
+      ws.on('close', () => {
+        this.connected = false;
+        console.error('[Telnyx STT] Connection closed');
+        if (this.transcriptReject && !this.closed) {
+          const rejectFn = this.transcriptReject;
+          this.transcriptReject = null;
+          this.transcriptResolve = null;
+          if (this.transcriptTimeout) clearTimeout(this.transcriptTimeout);
+          rejectFn(new Error('Telnyx STT connection closed'));
+        }
+      });
+
+      this.ws = ws;
+    });
+  }
+
+  sendAudio(audio: Buffer): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    this.ws.send(audio);
+  }
+
+  async waitForTranscript(timeoutMs?: number): Promise<string> {
+    const timeout = timeoutMs ?? (this.silenceDurationMs + 5000);
+    return new Promise((resolve, reject) => {
+      this.transcriptResolve = resolve;
+      this.transcriptReject = reject;
+      this.pendingTranscript = '';
+      this.transcriptTimeout = setTimeout(() => {
+        if (this.transcriptReject) {
+          const rejectFn = this.transcriptReject;
+          this.transcriptResolve = null;
+          this.transcriptReject = null;
+          rejectFn(new Error('Telnyx STT transcript timeout'));
+        }
+      }, timeout);
+    });
+  }
+
+  onPartial(callback: (partial: string) => void): void {
+    this.partialCallback = callback;
+  }
+
+  close(): void {
+    this.closed = true;
+    this.connected = false;
+    if (this.transcriptTimeout) clearTimeout(this.transcriptTimeout);
+    if (this.ws) {
+      try {
+        if (this.ws.readyState === WebSocket.OPEN) {
+          this.ws.send(JSON.stringify({ type: 'CloseStream' }));
+        }
+        this.ws.close();
+      } catch {}
+    }
+    this.ws = null;
+  }
+
+  isConnected(): boolean {
+    return this.connected && !this.closed;
+  }
+}

--- a/server/src/providers/stt-telnyx.ts
+++ b/server/src/providers/stt-telnyx.ts
@@ -75,9 +75,6 @@ class TelnyxSTTSession implements RealtimeSTTSession {
   private silenceDurationMs: number;
   private connected = false;
   private closed = false;
-  private reconnectAttempts = 0;
-  private maxReconnectAttempts = 5;
-  private reconnectDelayMs = 1000;
 
   private partialCallback: ((partial: string) => void) | null = null;
   private transcriptResolve: ((transcript: string) => void) | null = null;
@@ -116,7 +113,6 @@ class TelnyxSTTSession implements RealtimeSTTSession {
 
   async connect(): Promise<void> {
     this.closed = false;
-    this.reconnectAttempts = 0;
     return this.doConnect();
   }
 
@@ -126,9 +122,18 @@ class TelnyxSTTSession implements RealtimeSTTSession {
         headers: { Authorization: `Bearer ${this.apiKey}` },
       });
 
+      // Abort the connect attempt if the server never opens the session.
+      // Without this, a hung WebSocket would block initiateCall() forever.
+      const connectTimeout = setTimeout(() => {
+        if (!this.connected) {
+          try { ws.removeAllListeners(); ws.close(); } catch {}
+          reject(new Error('Telnyx STT connection timeout'));
+        }
+      }, 10000);
+
       ws.on('open', () => {
+        clearTimeout(connectTimeout);
         this.connected = true;
-        this.reconnectAttempts = 0;
         console.error('[Telnyx STT] Connected');
         resolve();
       });
@@ -165,6 +170,7 @@ class TelnyxSTTSession implements RealtimeSTTSession {
       });
 
       ws.on('error', (err: Error) => {
+        clearTimeout(connectTimeout);
         console.error(`[Telnyx STT] Error: ${err.message}`);
         if (!this.connected) reject(err);
         else if (this.transcriptReject) {
@@ -198,11 +204,18 @@ class TelnyxSTTSession implements RealtimeSTTSession {
   }
 
   async waitForTranscript(timeoutMs?: number): Promise<string> {
+    // If finals already arrived before anyone was listening (e.g. the user
+    // spoke during TTS playback), return the buffered transcript instead of
+    // dropping it on the floor.
+    if (this.pendingTranscript) {
+      const full = this.pendingTranscript;
+      this.pendingTranscript = '';
+      return full;
+    }
     const timeout = timeoutMs ?? (this.silenceDurationMs + 5000);
     return new Promise((resolve, reject) => {
       this.transcriptResolve = resolve;
       this.transcriptReject = reject;
-      this.pendingTranscript = '';
       this.transcriptTimeout = setTimeout(() => {
         if (this.transcriptReject) {
           const rejectFn = this.transcriptReject;

--- a/server/src/providers/tts-telnyx.ts
+++ b/server/src/providers/tts-telnyx.ts
@@ -11,13 +11,19 @@
  * interface. The phone bridge resamples to 8kHz and converts to mu-law
  * before sending to the caller.
  *
- * Protocol:
+ * Protocol (per https://developers.telnyx.com/docs/tts-stt/tts-websocket-streaming):
  *   - Connect with Authorization: Bearer <key> header.
  *   - Voice and audio format are set via URL query params.
  *   - Send init frame { "text": " ", "voice_settings": { "voice_speed": N } }.
  *   - Send text frame { "text": "..." } for each synthesis request.
- *   - Receive JSON frames: { "audio": "<base64 PCM>", "isFinal": bool }.
- *   - Send { "force": true } to flush synthesis.
+ *   - Receive JSON frames: { "audio": "<base64>", "isFinal": false } per chunk,
+ *     then a final frame { "audio": null, "text": "", "isFinal": true }.
+ *   - Send { "text": "" } to signal completion (NOT { "force": true }, which
+ *     interrupts mid-stream synthesis).
+ *
+ * Audio format is "linear16" (16-bit signed LE PCM) at 24kHz mono, matching
+ * the contract of TTSProvider.synthesize() and the resampler in phone-call.ts.
+ * Valid Telnyx formats: mp3, linear16, wav, mulaw, alaw, ogg_vorbis.
  *
  * Voices: see GET https://api.telnyx.com/v2/text-to-speech/voices
  * for the full catalog (AWS Polly, Azure, Google, ElevenLabs, Resemble, xAI).
@@ -31,7 +37,7 @@ export class TelnyxTTSProvider implements TTSProvider {
   readonly name = 'telnyx';
   private apiKey: string | null = null;
   private voice: string = 'AWS.Polly.Matthew-Neural';
-  private audioFormat: string = 'pcm';
+  private audioFormat: string = 'linear16';
   private sampleRate: number = 24000;
 
   initialize(config: TTSConfig): void {
@@ -40,7 +46,9 @@ export class TelnyxTTSProvider implements TTSProvider {
     }
     this.apiKey = config.apiKey;
     this.voice = config.voice || 'AWS.Polly.Matthew-Neural';
-    this.audioFormat = (config as any).audioFormat || 'pcm';
+    // "pcm" is not a valid Telnyx audio_format; the field default of
+    // "linear16" is what we actually want when no override is given.
+    this.audioFormat = (config as any).audioFormat || 'linear16';
     this.sampleRate = (config as any).sampleRate || 24000;
     console.error(`TTS provider: Telnyx (voice: ${this.voice}, ${this.sampleRate}Hz)`);
   }
@@ -59,21 +67,35 @@ export class TelnyxTTSProvider implements TTSProvider {
 
     return new Promise((resolve, reject) => {
       const chunks: Buffer[] = [];
+      let settled = false;
+      let timeoutHandle: NodeJS.Timeout | null = null;
       const ws = new WebSocket(this.buildUrl(), {
         headers: { Authorization: `Bearer ${this.apiKey}` },
       });
 
       const cleanup = () => {
+        if (timeoutHandle) {
+          clearTimeout(timeoutHandle);
+          timeoutHandle = null;
+        }
         try { ws.removeAllListeners(); ws.close(); } catch {}
       };
 
+      const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        fn();
+      };
+
       ws.on('open', () => {
-        // Init handshake frame
+        // Init handshake frame (single space, required)
         ws.send(JSON.stringify({ text: ' ', voice_settings: { voice_speed: 1.0 } }));
         // Text to synthesize
         ws.send(JSON.stringify({ text }));
-        // Force flush
-        ws.send(JSON.stringify({ force: true }));
+        // Stop frame: empty text signals completion per the Telnyx spec.
+        // NOT { force: true }, which interrupts mid-stream synthesis.
+        ws.send(JSON.stringify({ text: '' }));
       });
 
       ws.on('message', (data: WebSocket.RawData, isBinary: boolean) => {
@@ -86,8 +108,7 @@ export class TelnyxTTSProvider implements TTSProvider {
         }
 
         if (msg.error) {
-          cleanup();
-          reject(new Error(`Telnyx TTS error: ${msg.error}`));
+          settle(() => reject(new Error(`Telnyx TTS error: ${msg.error}`)));
           return;
         }
 
@@ -97,33 +118,36 @@ export class TelnyxTTSProvider implements TTSProvider {
         }
 
         if (msg.isFinal) {
-          cleanup();
-          resolve(Buffer.concat(chunks));
+          settle(() => resolve(Buffer.concat(chunks)));
         }
       });
 
       ws.on('error', (err: Error) => {
-        cleanup();
-        reject(new Error(`Telnyx TTS WebSocket error: ${err.message}`));
+        settle(() => reject(new Error(`Telnyx TTS WebSocket error: ${err.message}`)));
       });
 
       ws.on('close', () => {
-        // If we have any chunks but no isFinal, resolve with what we have
-        if (chunks.length > 0) {
-          resolve(Buffer.concat(chunks));
-        } else {
-          reject(new Error('Telnyx TTS connection closed before audio received'));
-        }
+        // Server closed before isFinal. Resolve with whatever we have so
+        // short utterances that flush quickly still play; reject only if we
+        // got nothing at all.
+        settle(() => {
+          if (chunks.length > 0) {
+            resolve(Buffer.concat(chunks));
+          } else {
+            reject(new Error('Telnyx TTS connection closed before audio received'));
+          }
+        });
       });
 
       // 30s timeout
-      setTimeout(() => {
-        cleanup();
-        if (chunks.length > 0) {
-          resolve(Buffer.concat(chunks));
-        } else {
-          reject(new Error('Telnyx TTS timeout'));
-        }
+      timeoutHandle = setTimeout(() => {
+        settle(() => {
+          if (chunks.length > 0) {
+            resolve(Buffer.concat(chunks));
+          } else {
+            reject(new Error('Telnyx TTS timeout'));
+          }
+        });
       }, 30000);
     });
   }

--- a/server/src/providers/tts-telnyx.ts
+++ b/server/src/providers/tts-telnyx.ts
@@ -1,0 +1,130 @@
+/**
+ * Telnyx TTS Provider
+ *
+ * Streaming text-to-speech via the Telnyx WebSocket API.
+ * Endpoint: wss://api.telnyx.com/v2/text-to-speech/speech
+ *
+ * Uses the same Telnyx API key as the phone provider, so no extra
+ * account or credential is needed when CALLME_PHONE_PROVIDER=telnyx.
+ *
+ * Returns a PCM audio buffer (16-bit, mono) matching the TTSProvider
+ * interface. The phone bridge resamples to 8kHz and converts to mu-law
+ * before sending to the caller.
+ *
+ * Protocol:
+ *   - Connect with Authorization: Bearer <key> header.
+ *   - Voice and audio format are set via URL query params.
+ *   - Send init frame { "text": " ", "voice_settings": { "voice_speed": N } }.
+ *   - Send text frame { "text": "..." } for each synthesis request.
+ *   - Receive JSON frames: { "audio": "<base64 PCM>", "isFinal": bool }.
+ *   - Send { "force": true } to flush synthesis.
+ *
+ * Voices: see GET https://api.telnyx.com/v2/text-to-speech/voices
+ * for the full catalog (AWS Polly, Azure, Google, ElevenLabs, Resemble, xAI).
+ * Default is AWS.Polly.Matthew-Neural (en-US male).
+ */
+
+import WebSocket from 'ws';
+import type { TTSProvider, TTSConfig } from './types.js';
+
+export class TelnyxTTSProvider implements TTSProvider {
+  readonly name = 'telnyx';
+  private apiKey: string | null = null;
+  private voice: string = 'AWS.Polly.Matthew-Neural';
+  private audioFormat: string = 'pcm';
+  private sampleRate: number = 24000;
+
+  initialize(config: TTSConfig): void {
+    if (!config.apiKey) {
+      throw new Error('Telnyx API key required for TTS');
+    }
+    this.apiKey = config.apiKey;
+    this.voice = config.voice || 'AWS.Polly.Matthew-Neural';
+    this.audioFormat = (config as any).audioFormat || 'pcm';
+    this.sampleRate = (config as any).sampleRate || 24000;
+    console.error(`TTS provider: Telnyx (voice: ${this.voice}, ${this.sampleRate}Hz)`);
+  }
+
+  private buildUrl(): string {
+    const params = new URLSearchParams({
+      voice: this.voice,
+      audio_format: this.audioFormat,
+      sample_rate: String(this.sampleRate),
+    });
+    return `wss://api.telnyx.com/v2/text-to-speech/speech?${params.toString()}`;
+  }
+
+  async synthesize(text: string): Promise<Buffer> {
+    if (!this.apiKey) throw new Error('Telnyx TTS not initialized');
+
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      const ws = new WebSocket(this.buildUrl(), {
+        headers: { Authorization: `Bearer ${this.apiKey}` },
+      });
+
+      const cleanup = () => {
+        try { ws.removeAllListeners(); ws.close(); } catch {}
+      };
+
+      ws.on('open', () => {
+        // Init handshake frame
+        ws.send(JSON.stringify({ text: ' ', voice_settings: { voice_speed: 1.0 } }));
+        // Text to synthesize
+        ws.send(JSON.stringify({ text }));
+        // Force flush
+        ws.send(JSON.stringify({ force: true }));
+      });
+
+      ws.on('message', (data: WebSocket.RawData, isBinary: boolean) => {
+        if (isBinary) return;
+        let msg: any;
+        try {
+          msg = JSON.parse(data.toString());
+        } catch {
+          return;
+        }
+
+        if (msg.error) {
+          cleanup();
+          reject(new Error(`Telnyx TTS error: ${msg.error}`));
+          return;
+        }
+
+        if (msg.audio) {
+          const audioBytes = Buffer.from(msg.audio, 'base64');
+          chunks.push(audioBytes);
+        }
+
+        if (msg.isFinal) {
+          cleanup();
+          resolve(Buffer.concat(chunks));
+        }
+      });
+
+      ws.on('error', (err: Error) => {
+        cleanup();
+        reject(new Error(`Telnyx TTS WebSocket error: ${err.message}`));
+      });
+
+      ws.on('close', () => {
+        // If we have any chunks but no isFinal, resolve with what we have
+        if (chunks.length > 0) {
+          resolve(Buffer.concat(chunks));
+        } else {
+          reject(new Error('Telnyx TTS connection closed before audio received'));
+        }
+      });
+
+      // 30s timeout
+      setTimeout(() => {
+        cleanup();
+        if (chunks.length > 0) {
+          resolve(Buffer.concat(chunks));
+        } else {
+          reject(new Error('Telnyx TTS timeout'));
+        }
+      }, 30000);
+    });
+  }
+}


### PR DESCRIPTION
## What this changes

Adds **Telnyx STT and TTS providers** so that when you're already using Telnyx as your phone provider, you can use Telnyx for speech-to-text and text-to-speech too, with the same API key. No separate OpenAI account needed for speech services.

CallMe already recommends Telnyx as the default phone provider ("50% cheaper"). This PR completes the "Telnyx everywhere" story: phone, STT, and TTS all on one account, one key, one bill.

### Files

| File | Change |
|---|---|
| `server/src/providers/stt-telnyx.ts` | New. `TelnyxSTTProvider` implementing `RealtimeSTTProvider`. Streaming STT via WebSocket. |
| `server/src/providers/tts-telnyx.ts` | New. `TelnyxTTSProvider` implementing `TTSProvider`. Streaming TTS via WebSocket. |
| `server/src/providers/index.ts` | Wire Telnyx into the provider factory. Add `STTProviderType`, `sttProvider` config field, Telnyx-specific env vars. Auto-detect `telnyx` as default STT when `CALLME_PHONE_PROVIDER=telnyx`. Relax OpenAI key requirement when using Telnyx for both STT and TTS. |
| `.env.example` | Document Telnyx STT/TTS env vars. |
| `README.md` | Update variables tables with Telnyx STT/TTS options. |

### How it works

**STT** (`wss://api.telnyx.com/v2/speech-to-text/transcription`):
- Streaming transcription over WebSocket. Config via URL query params (`transcription_engine`, `input_format`, `sample_rate`, `language`).
- Accepts **mu-law audio directly** (8kHz mono), which is the format the phone bridge already produces. No audio conversion needed, unlike the OpenAI Realtime STT path.
- Configurable engine: `Telnyx`, `Deepgram`, `Google`, or `Azure`.

**TTS** (`wss://api.telnyx.com/v2/text-to-speech/speech`):
- Streaming synthesis over WebSocket. Returns raw PCM audio (base64-encoded), matching the existing `TTSProvider.synthesize()` interface.
- Voice catalog at `GET /v2/text-to-speech/voices` (AWS Polly, Azure, Google, ElevenLabs, Resemble, xAI). Default: `AWS.Polly.Matthew-Neural`.

Both providers fall back to `CALLME_PHONE_AUTH_TOKEN` when `CALLME_TELNYX_API_KEY` is not set, so zero extra config is needed when already using Telnyx for phone.

### How I tested it

- `tsc --noEmit` passes (no type errors)
- Verified the Telnyx STT WebSocket returns transcripts against the live API: connected to `wss://api.telnyx.com/v2/speech-to-text/transcription?transcription_engine=Telnyx&input_format=linear16&sample_rate=8000`, sent raw PCM binary frames, received `{"transcript":" you","confidence":null,"is_final":true}`.
- Verified the Telnyx TTS REST endpoint returns audio (MP3) against the live API. The WebSocket path returns raw PCM per the [pipecat Telnyx TTS service](https://github.com/pipecat-ai/pipecat) protocol (init frame `{"text":" ","voice_settings":{"voice_speed":N}}`, text frames `{"text":"..."}`, audio frames `{"audio":"<base64>"}`, final frame `{"isFinal":true}`).
- No new dependencies added. Uses the existing `ws` package for WebSocket connections.

### Environment variables

| Variable | Default | Description |
|---|---|---|
| `CALLME_STT_PROVIDER` | `telnyx`* | `openai-realtime` or `telnyx`. *Auto-defaults to `telnyx` when `CALLME_PHONE_PROVIDER=telnyx` |
| `CALLME_TTS_PROVIDER` | `openai` | `openai`, `kokoro`, or `telnyx` |
| `CALLME_TELNYX_API_KEY` | - | Telnyx API key for STT/TTS (defaults to `CALLME_PHONE_AUTH_TOKEN`) |
| `CALLME_TELNYX_STT_ENGINE` | `Telnyx` | STT engine: `Telnyx`, `Deepgram`, `Google`, `Azure` |
| `CALLME_TELNYX_STT_INPUT_FORMAT` | `mulaw` | Audio format: `mulaw`, `linear16`, `alaw` |
| `CALLME_TELNYX_STT_LANGUAGE` | `en-US` | BCP-47 language code |
| `CALLME_TELNYX_TTS_VOICE` | `AWS.Polly.Matthew-Neural` | Voice ID (see `/v2/text-to-speech/voices`) |
